### PR TITLE
style: replace image buttons with icon spans for consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.3.0</version>
+        <version>15.3.1</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.json-editor</artifactId>

--- a/src/main/resources/webapp/json-editor/css/json-editor.css
+++ b/src/main/resources/webapp/json-editor/css/json-editor.css
@@ -18,7 +18,7 @@
     appearance: none !important;
     -webkit-appearance: none !important;
     -moz-appearance: none !important;
-    background: transparent url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAYAAAAGCAYAAADgzO9IAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAOUlEQVR4nGNgwAOKGRgY/qNhkBgDCwMDw0UkwasMDAysMF22DAwM/6ASjuhGLmVgYFiCzS5JKAYDACJtDIY1VpdwAAAAAElFTkSuQmCC") no-repeat;
+    background: transparent var(--sbb-combo-chevron) no-repeat;
     background-position: calc(100% - 1rem) 55% !important;
     padding: 5px 3rem 5px 1rem;
     font-weight: 600;
@@ -45,24 +45,10 @@
     margin-top: 10px;
 }
 
-.editor-buttons button {
-    background-color: transparent;
-    border: 1px solid #DEDEDE;
-    color: #555;
-    padding: 4px 8px;
-    font-size: 12px;
-    font-weight: bold;
-    cursor: pointer;
-}
-
+/* Button chrome (transparent action button) comes from the shared system (generic buttons.css
+   aliases `.editor-buttons button`). Only the layout / divider / icon / disabled bits stay local. */
 .editor-buttons button:not(:first-child) {
     margin-left: 5px;
-}
-
-.editor-buttons button:disabled {
-    text-shadow: white 1px 1px 0.01em;
-    color: #C9D1D7;
-    cursor: default;
 }
 
 .editor-buttons .divider {
@@ -72,13 +58,10 @@
     border-left-color: #ccc;
 }
 
-.editor-buttons button img {
+.editor-buttons button img,
+.editor-buttons button [class*="sbb-icon-"] {
     margin-right: 6px;
     vertical-align: bottom;
-}
-
-.editor-buttons button:disabled img {
-    opacity: 0.3;
 }
 
 .validation-pass {

--- a/src/main/resources/webapp/json-editor/css/json-editor.css
+++ b/src/main/resources/webapp/json-editor/css/json-editor.css
@@ -45,8 +45,10 @@
     margin-top: 10px;
 }
 
-/* Button chrome (transparent action button) comes from the shared system (generic buttons.css
-   aliases `.editor-buttons button`). Only the layout / divider / icon / disabled bits stay local. */
+/* Button chrome (transparent action button) and the disabled state come from the shared system
+   (generic buttons.css aliases `.editor-buttons button` and `.editor-buttons button:disabled`, the
+   latter fading the whole button — icon span included — via opacity). Only the layout / divider /
+   icon-spacing bits stay local. */
 .editor-buttons button:not(:first-child) {
     margin-left: 5px;
 }

--- a/src/main/resources/webapp/json-editor/html/json-editor.html
+++ b/src/main/resources/webapp/json-editor/html/json-editor.html
@@ -23,17 +23,17 @@
 
 <div class='editor-buttons'>
     <button type='button' id='edit-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/edit.gif' alt='edit'>Edit
+        <span class='sbb-icon-edit' role='img' aria-label='edit'></span>Edit
     </button>
     <button type='button' class='divider'>&nbsp;</button>
     <button type='button' id='validate-json-button' disabled>
         <img class='append-build-number' src='/polarion/icons/default/enums/req_status_reviewed.gif' alt='reviewed'>Validate
     </button>
     <button type='button' id='save-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/save.gif' alt='save'>Save
+        <span class='sbb-icon-save' role='img' aria-label='save'></span>Save
     </button>
     <button type='button' id='cancel-edit-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/cancel.gif' alt='cancel'>Cancel
+        <span class='sbb-icon-cancel' role='img' aria-label='cancel'></span>Cancel
     </button>
 </div>
 <div class='validation-result'>

--- a/src/test/resources/editor-ok-module.html
+++ b/src/test/resources/editor-ok-module.html
@@ -23,17 +23,17 @@
 
 <div class='editor-buttons'>
     <button type='button' id='edit-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/edit.gif' alt='edit'>Edit
+        <span class='sbb-icon-edit' role='img' aria-label='edit'></span>Edit
     </button>
     <button type='button' class='divider'>&nbsp;</button>
     <button type='button' id='validate-json-button' disabled>
         <img class='append-build-number' src='/polarion/icons/default/enums/req_status_reviewed.gif' alt='reviewed'>Validate
     </button>
     <button type='button' id='save-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/save.gif' alt='save'>Save
+        <span class='sbb-icon-save' role='img' aria-label='save'></span>Save
     </button>
     <button type='button' id='cancel-edit-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/cancel.gif' alt='cancel'>Cancel
+        <span class='sbb-icon-cancel' role='img' aria-label='cancel'></span>Cancel
     </button>
 </div>
 <div class='validation-result'>

--- a/src/test/resources/editor-ok.html
+++ b/src/test/resources/editor-ok.html
@@ -23,17 +23,17 @@
 
 <div class='editor-buttons'>
     <button type='button' id='edit-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/edit.gif' alt='edit'>Edit
+        <span class='sbb-icon-edit' role='img' aria-label='edit'></span>Edit
     </button>
     <button type='button' class='divider'>&nbsp;</button>
     <button type='button' id='validate-json-button' disabled>
         <img class='append-build-number' src='/polarion/icons/default/enums/req_status_reviewed.gif' alt='reviewed'>Validate
     </button>
     <button type='button' id='save-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/save.gif' alt='save'>Save
+        <span class='sbb-icon-save' role='img' aria-label='save'></span>Save
     </button>
     <button type='button' id='cancel-edit-json-button' disabled>
-        <img class='append-build-number' src='/polarion/ria/images/actions/cancel.gif' alt='cancel'>Cancel
+        <span class='sbb-icon-cancel' role='img' aria-label='cancel'></span>Cancel
     </button>
 </div>
 <div class='validation-result'>


### PR DESCRIPTION
### Proposed changes

- Updated button elements in editor HTML files to use span elements with icon classes instead of image tags for a more consistent styling approach.
- Modified CSS to accommodate the new icon spans.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
