### PR TITLE
fix: harden the UI build (no dev token in bundles, install from the lock)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,12 +164,21 @@
                         </goals>
                         <phase>generate-resources</phase>
                     </execution>
+                    <!-- `ci`, not the plugin's default `install`: the production bundle must come
+                         from the committed package-lock.json, which is the graph the dockerized tests
+                         exercise (they run `npm ci` too). With `install` the caret ranges could resolve
+                         differently here than in the tests, so we would ship something we never ran.
+                         It also turns a package.json/lock mismatch into a failed build instead of
+                         silently repairing it. -->
                     <execution>
                         <id>npm install</id>
                         <goals>
                             <goal>npm</goal>
                         </goals>
                         <phase>generate-resources</phase>
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>npm build</id>

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -54,6 +54,13 @@ export default defineConfig(({ command, mode }) => {
   return {
     plugins: [react()],
     resolve,
+    // Never let a developer's personal access token reach a shipped bundle. VITE_BEARER_TOKEN is a
+    // `vite dev` convenience (it switches useRemote to the token-authenticated /api endpoints); Vite
+    // inlines import.meta.env.VITE_* at build time, so a local .env.local would otherwise be baked
+    // into the bundle that `mvn -P install-to-local-polarion` deploys, readable by everyone the SPA is
+    // served to. Forcing it undefined here keeps production on the session-authenticated /internal
+    // endpoints, which is what Polarion provides anyway.
+    define: { 'import.meta.env.VITE_BEARER_TOKEN': 'undefined' },
     base: '/polarion/json-editor-app/ui/app/',
     build: {
       outDir: './dist/app',

--- a/ui/vite.formext.config.js
+++ b/ui/vite.formext.config.js
@@ -23,6 +23,9 @@ export default defineConfig({
   // automatically, so without it React bundles its larger dev build with runtime warnings).
   define: {
     'process.env.NODE_ENV': JSON.stringify('production'),
+    // Same reason as in vite.config.js: these bundles ship to Polarion too, so a developer's
+    // VITE_BEARER_TOKEN must never be inlined into them.
+    'import.meta.env.VITE_BEARER_TOKEN': 'undefined',
   },
   build: {
     outDir: './dist/app/assets',


### PR DESCRIPTION
### Proposed changes

Closes #125.

Two defects in the React build wiring, both found while reviewing the follow-up PRs.

**1. The dev bearer token could be baked into a shipped bundle.** `VITE_BEARER_TOKEN` is a
`vite dev` convenience — it switches `useRemote` to the token-authenticated `/api` endpoints so the
app can talk to a real Polarion without a session. Vite inlines `import.meta.env.VITE_*` at **build**
time, so a developer with `.env.local` present baked their personal access token into the bundle that
`mvn -P install-to-local-polarion` deploys, where every user served the SPA could read it. Forcing it
`undefined` in the production config closes that; dev is untouched, and in Polarion the
session-authenticated `/internal` endpoints are what the app should use anyway.

Note for this extension: the guard is needed in **both** Vite configs. Patching only `vite.config.js`
left the form-extension bundles (`vite.formext.config.js`) still leaking — they are built by a second
`vite build` and ship to Polarion as well. Verified by rebuilding and grepping `dist/` again.

**2. The production bundle was not installed from the lock.** The `npm install` execution carried no
`<arguments>`, so it ran the frontend-maven-plugin default while the dockerized test suite installs
with `npm ci`. The packaged bundle could resolve the caret ranges differently from the graph the tests
exercised — we could ship something we never ran. `ci` also turns a `package.json`/lock mismatch into
a failed build instead of silently repairing it. The local-RSP iteration flow is unaffected: it already
prescribes `npm install` inside `ui/` after editing `package.json`, which updates the lock.

### How to test

```bash
cd ui && VITE_BEARER_TOKEN=SECRET-TOKEN-12345 npm run build
grep -r 'SECRET-TOKEN-12345' dist/    # before: found in dist/app/assets/index-*.js; after: nothing
```

`mvn -o clean compile` logs `Running 'npm ci'` and succeeds.

### Checklist

- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works — the leak is verified by the build-and-grep above; the change itself is build configuration, which the existing dockerized suite exercises
- [x] If applicable, I have checked that any relevant tests pass after adding my changes — full dockerized suite green
- [x] I have updated any relevant documentation