### PR TITLE
build: move the parent to generic 15.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.8.1</version>
+        <version>15.9.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.json-editor</artifactId>


### PR DESCRIPTION
Parent `15.8.1` → `15.9.0`. One line; the whole diff.

15.9.0 adds `-DnpmIgnoreUserConfig`, an opt-in flag that runs npm with an empty user config — for CI agents whose npm configuration a build cannot fix and must not inherit. **Nothing here uses it**: this repository's CI has no such configuration to work around, so the bump only keeps the parent current.

Verified with a full `mvn clean install -P install-to-local-polarion`: Java tests and the dockerized Vitest suite both green.