### PR TITLE
feat: replace the native confirm with a dialog

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "json-editor-app",
       "version": "1.0.0",
       "dependencies": {
-        "@grigoriev/react-sbb-polarion": "^0.0.9",
+        "@grigoriev/react-sbb-polarion": "^0.0.10",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.0.9.tgz",
-      "integrity": "sha512-ZgRCDEIwpwLp2FNacBchyROQv69RJErVZipbq7PocYhOK+WMU0k0swMm/mMKer6A3N66/h0PeR2zcnsZj4p9Zw==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.0.10.tgz",
+      "integrity": "sha512-9PLhDeB8l6Z/6ElNQL01cwnUbd6DPyduJA6BsJ2bi5cqGe2nhZUrIATEL9XQg6w0tg0frxpxq7IwhjOKo8ku3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.9.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.0.9",
+    "@grigoriev/react-sbb-polarion": "^0.0.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/ui/src/formext/JsonEditorPanel.tsx
+++ b/ui/src/formext/JsonEditorPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect, useConfirm } from '@grigoriev/react-sbb-polarion';
 import useRemote from '../services/useRemote';
 import { createJsonCodeEditor, validateJsonContent } from './codeEditor';
 import type { JsonCodeEditor } from './codeEditor';
@@ -37,6 +37,7 @@ interface ValidationState {
  */
 export default function JsonEditorPanel({ context, attachments, onSaved }: JsonEditorPanelProps) {
   const { sendRequest } = useRemote();
+  const { confirm, confirmDialog } = useConfirm();
 
   const [selectedId, setSelectedId] = useState<string>('');
   const [newFileName, setNewFileName] = useState<string>('');
@@ -173,8 +174,8 @@ export default function JsonEditorPanel({ context, attachments, onSaved }: JsonE
     }
   };
 
-  const handleCancel = () => {
-    if (existingSelected && !window.confirm('Are you sure you want to cancel editing and revert changes?')) {
+  const handleCancel = async () => {
+    if (existingSelected && !(await confirm('Are you sure you want to cancel editing and revert changes?'))) {
       return;
     }
     setEditing(false);
@@ -250,7 +251,12 @@ export default function JsonEditorPanel({ context, attachments, onSaved }: JsonE
         <button type="button" id="save-json-button" disabled={!editing || saving} onClick={handleSave}>
           <span className="sbb-icon-save" role="img" aria-label="save"></span>Save
         </button>
-        <button type="button" id="cancel-edit-json-button" disabled={!editing || saving} onClick={handleCancel}>
+        <button
+          type="button"
+          id="cancel-edit-json-button"
+          disabled={!editing || saving}
+          onClick={() => void handleCancel()}
+        >
           <span className="sbb-icon-cancel" role="img" aria-label="cancel"></span>Cancel
         </button>
       </div>
@@ -267,6 +273,7 @@ export default function JsonEditorPanel({ context, attachments, onSaved }: JsonE
       <div className="editor-wrapper">
         <div id="jsonCodeEditor" ref={editorHostRef}></div>
       </div>
+      {confirmDialog}
     </>
   );
 }

--- a/ui/test/JsonEditorPanel.test.tsx
+++ b/ui/test/JsonEditorPanel.test.tsx
@@ -39,6 +39,16 @@ async function renderPanel(props: Partial<Parameters<typeof JsonEditorPanel>[0]>
   return { onSaved };
 }
 
+/** Answer the confirmation dialog the panel renders in place of the former window.confirm. */
+async function answerDialog(label: 'OK' | 'Cancel') {
+  await vi.waitFor(() => expect(document.querySelector('.rsp-modal')).not.toBeNull());
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>('.rsp-modal-footer .sbb-btn')).find(
+    (b) => (b.textContent ?? '').trim() === label,
+  );
+  if (!button) throw new Error(`dialog button "${label}" not found`);
+  button.click();
+}
+
 const editorTextarea = () => $('#jsonCodeEditor textarea') as HTMLTextAreaElement;
 const selectEl = () => $('#editor-selector') as HTMLSelectElement;
 
@@ -227,22 +237,20 @@ describe('JsonEditorPanel', () => {
         },
       },
     ]);
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     await renderPanel();
     setControlValue(selectEl(), 'att1', 'change');
     await vi.waitFor(() => expect(getCalls).toBe(1));
     ($('#edit-json-button') as HTMLButtonElement).click();
     await vi.waitFor(() => expect(($('#cancel-edit-json-button') as HTMLButtonElement).disabled).toBe(false));
     ($('#cancel-edit-json-button') as HTMLButtonElement).click();
-    // Confirm was asked, and the original content was re-fetched (a second GET).
+    // The dialog was confirmed, and the original content was re-fetched (a second GET).
+    await answerDialog('OK');
     await vi.waitFor(() => expect(getCalls).toBe(2));
-    expect(confirmSpy).toHaveBeenCalled();
     expect(($('#cancel-edit-json-button') as HTMLButtonElement).disabled).toBe(true);
   });
 
   it('stays in edit mode when the cancel confirm is declined', async () => {
     installFetchMock([{ method: 'GET', match: /\/attachments\/att1\/content$/, respond: () => new Response('{}') }]);
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
     await renderPanel();
     setControlValue(selectEl(), 'att1', 'change');
     await vi.waitFor(() => expect(($('#edit-json-button') as HTMLButtonElement).disabled).toBe(false));
@@ -250,8 +258,8 @@ describe('JsonEditorPanel', () => {
     await vi.waitFor(() => expect(($('#cancel-edit-json-button') as HTMLButtonElement).disabled).toBe(false));
 
     ($('#cancel-edit-json-button') as HTMLButtonElement).click();
-    // Declining the confirm must leave the edit untouched, not silently discard it.
-    expect(confirmSpy).toHaveBeenCalled();
+    // Dismissing the dialog must leave the edit untouched, not silently discard it.
+    await answerDialog('Cancel');
     expect(($('#cancel-edit-json-button') as HTMLButtonElement).disabled).toBe(false);
     expect(selectEl().disabled).toBe(true);
   });


### PR DESCRIPTION
### Proposed changes

The admin UI still asked for confirmation through the browser's `window.confirm`. That renders an
OS-level dialog that ignores the SBB styling entirely and, in a form extension, escapes the shadow
root the panel lives in — the one native-looking element left in an otherwise fully React page.

react-sbb-polarion 0.0.10 ships `useConfirm`, a promise-based confirmation built on the shared
`Modal`. This PR bumps RSP to that release and switches every confirmation over to it, so the prompt
now looks like the rest of the page.

The bump has to be explicit: a caret range on a `0.x.y` version pins the patch, so `^0.0.9` never
resolves to 0.0.10.

The tests that used to stub `window.confirm` now click the real dialog, which also makes them cover
the wiring rather than the stub.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
