### PR TITLE
chore: family maintenance sweep

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -133,6 +133,7 @@ jobs:
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" clean deploy \
             -Dmaven.test.skip=true \
+            -DskipJsTests=true \
             -P gpg-sign \
             -P central-publishing \
             -Dcentral.timeout=3600 \
@@ -177,6 +178,7 @@ jobs:
         run: |
           mvn --batch-mode -s "${SETTINGS_XML}" deploy \
             -Dmaven.test.skip=true \
+            -DskipJsTests=true \
             -Dmaven.javadoc.skip=true \
             -Dmaven.source.skip=true \
             -P deploy-github-packages

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,7 +23,6 @@ jobs:
     env:
       IO_JFROG_SBB_POLARION_TOKEN: ${{ secrets.IO_JFROG_SBB_POLARION_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR: true
       GITHUB_TOKEN: ${{ github.token }}  # Providing this prevents reaching the GitHub request limits
     steps:
       - name: 📄 Checkout the repository

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -81,6 +81,27 @@
         ]
       }
     },
+    "/api/disclaimer": {
+      "get": {
+        "operationId": "getDisclaimer",
+        "responses": {
+          "default": {
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "HTML help article"
+          }
+        },
+        "summary": "Returns the build-generated DISCLAIMER help article shown on the Usage Disclaimer page",
+        "tags": [
+          "Extension Information"
+        ]
+      }
+    },
     "/api/projects/{projectId}/documents/{spaceId}/{documentName}/attachments": {
       "post": {
         "operationId": "createDocumentAttachment",

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
                 <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <configuration>
                     <outputFormat>JSON</outputFormat>
-                    <sortOutput>true</sortOutput>
                     <resourcePackages>
                         <package>ch.sbb.polarion.extension.generic.rest.controller.info</package>
                         <package>ch.sbb.polarion.extension.generic.rest.model</package>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,17 @@
             <artifactId>ch.sbb.polarion.extension.generic.app</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+        <!-- generic's test helpers: the JUnit extensions that give a test a Polarion context.
+             Note when building generic from source: -DskipTests still packages this test-jar,
+             -Dmaven.test.skip=true does not, and this build then fails resolving it. -->
+        <dependency>
+            <groupId>ch.sbb.polarion.extensions</groupId>
+            <artifactId>ch.sbb.polarion.extension.generic.app</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,10 @@
 
         <web.app.name>${maven-jar-plugin.Extension-Context}</web.app.name>
 
-        <!--suppress UnresolvedMavenProperty -->
-        <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>
+        <!-- A broken README.md -> about.html conversion fails the build instead of shipping an
+             empty About page. markdown2html renders locally since 1.7.x - no GitHub API, no token -
+             so the same setting is right in CI, in a deploy job and on a developer machine. -->
+        <markdown2html-maven-plugin.failOnError>true</markdown2html-maven-plugin.failOnError>
 
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>15.10.1</version>
+        <version>15.11.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.json-editor</artifactId>


### PR DESCRIPTION
### Proposed changes

Routine maintenance sweep across the extension family. This repository's share:

- ci: skip the UI suite in the deploy jobs
- build: depend on generic's test-jar
- build: bump the generic parent to 15.11.0

The parent bump is the one change here with a runtime effect: the extension ships against generic 15.11.0, which adds the inherited `/disclaimer` endpoint (so `docs/openapi.json`, regenerated by the build, now documents `/api/disclaimer`) and pins `jakarta.annotation` to the API bundle, without which a filter's `@Priority` was ignored and the authentication and authorization filters ordered by `HashSet` iteration order - differently on each JVM start.

Nothing else touches runtime sources: the remaining commits change CI workflows, poms, tests and docs.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
