### PR TITLE
chore: drop the dead SbbCommon reference from the attachment REST docs

### DIFF
--- a/ui/src/formext/restApi.ts
+++ b/ui/src/formext/restApi.ts
@@ -2,10 +2,10 @@ import type { SendRequest } from '@grigoriev/react-sbb-polarion';
 import type { PanelContext } from './types';
 
 /**
- * Attachment REST calls for the JSON editor panel, ported from the legacy json-editor.js
- * (SbbCommon.callAsync) onto the extension's `useRemote().sendRequest`. The base path selects the
- * WorkItem or Document endpoints exactly as the legacy `entityBaseUrl` did, URL-encoding every path
- * segment so names with spaces / special characters are transmitted correctly.
+ * Attachment REST calls for the JSON editor panel, issued through the extension's
+ * `useRemote().sendRequest`. The base path selects the WorkItem or Document endpoints and
+ * URL-encodes every path segment, so names with spaces or special characters are transmitted
+ * correctly.
  */
 export function entityBasePath(ctx: PanelContext): string {
   const project = encodeURIComponent(ctx.projectId);


### PR DESCRIPTION
### Proposed changes

The doc comment on `ui/src/formext/restApi.ts` named three artifacts as this module's origin:

- `json-editor.js` — the legacy webapp JS, already removed from this repo
- `SbbCommon.callAsync` — removed from `generic` in 16.0.0
- `entityBaseUrl` — gone with the legacy file

All three are now unreachable, so a reader grepping for any of them finds nothing. The comment was accurate as history but no longer navigable.

Every behavioural statement is kept: WorkItem vs Document endpoint selection, and per-segment URL encoding so names with spaces or special characters survive.

Comment-only change. `tsc --noEmit` passes.

### Checklist

- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation